### PR TITLE
fix(deploy): repair MDX parse errors blocking prod build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the syllago documentation site.
 
+## 2026-04-25
+
+### Fixed
+- `src/content/docs/errors/moat-001.mdx` — replaced `<url>` autolink with a bare URL. MDX interprets `<` as JSX syntax and fails to parse angle-bracket autolinks; this had been breaking `astro build` (and therefore prod deploys) since the 2026-04-22 accuracy-review commit.
+- `src/content/docs/using-syllago/content-types/{hooks,index}.mdx` — removed the `<!-- vale off -->` / `<!-- vale on -->` HTML-comment markers that wrapped the `AUTO-GENERATED:HOOKS-EVENTS` and `AUTO-GENERATED:COMPAT-MATRIX` codegen blocks. MDX parses `<!` as JSX and couldn't process the files. The codegen blocks are pure backticked-identifier tables with no prose, so Vale doesn't fire on them even without suppression.
+- `vale/styles/Syllago/Acronyms.yml` — added `AUTO`, `END`, `HOOKS`, `START` to exceptions. These are code tokens inside the `{/* AUTO-GENERATED:HOOKS-EVENTS START */}` codegen markers, not real acronyms. Without this, removing the Vale-off HTML comments above would trip 10 spell-out suggestions against the marker text itself.
+
 ## 2026-04-24
 
 ### Added

--- a/src/content/docs/errors/moat-001.mdx
+++ b/src/content/docs/errors/moat-001.mdx
@@ -31,7 +31,7 @@ Pick one of the three supported paths:
    ```
 3. **Skip MOAT** — if you only need unsigned git content, omit `--moat` and the signing flags. Syllago will fall back to the legacy git-clone flow (no signature verification).
 
-For the full workflow, see <https://openscribbler.github.io/syllago-docs/moat/registry-add-signing-identity/>.
+For the full workflow, see https://openscribbler.github.io/syllago-docs/moat/registry-add-signing-identity/.
 
 ## Example Output
 

--- a/src/content/docs/using-syllago/content-types/hooks.mdx
+++ b/src/content/docs/using-syllago/content-types/hooks.mdx
@@ -26,7 +26,6 @@ Hooks support four handler types:
 
 Hook events use provider-neutral names in the canonical format. The table below lists events supported by both Claude Code and Gemini CLI; see the [Hook Event Matrix](/reference/hook-events/) for every canonical event across all providers.
 
-<!-- vale off -->
 {/* AUTO-GENERATED:HOOKS-EVENTS START — managed by scripts/sync-providers.ts. Do not edit by hand. */}
 | Canonical Event | Claude Code | Gemini CLI |
 |---|---|---|
@@ -39,7 +38,6 @@ Hook events use provider-neutral names in the canonical format. The table below 
 | `session_end` | `SessionEnd` | `SessionEnd` |
 | `session_start` | `SessionStart` | `SessionStart` |
 {/* AUTO-GENERATED:HOOKS-EVENTS END */}
-<!-- vale on -->
 
 Syllago translates event names automatically when converting between providers.
 

--- a/src/content/docs/using-syllago/content-types/index.mdx
+++ b/src/content/docs/using-syllago/content-types/index.mdx
@@ -7,7 +7,6 @@ Syllago manages several content types, each stored in a provider-neutral **sylla
 
 ## Provider compatibility matrix
 
-<!-- vale off -->
 {/* AUTO-GENERATED:COMPAT-MATRIX START — managed by scripts/sync-providers.ts. Do not edit by hand. */}
 | Content Type | Amp | Claude | Cline | Codex | Copilot | Crush | Cursor | Factory | Gemini | Kiro | OpenCode | Pi | Roo | Windsurf | Zed |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
@@ -18,7 +17,6 @@ Syllago manages several content types, each stored in a provider-neutral **sylla
 | Hooks | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ | — | ✅ | — | ✅ | — |
 | Commands | — | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ | — |
 {/* AUTO-GENERATED:COMPAT-MATRIX END */}
-<!-- vale on -->
 
 ## Content type reference
 

--- a/vale/styles/Syllago/Acronyms.yml
+++ b/vale/styles/Syllago/Acronyms.yml
@@ -8,11 +8,14 @@ second: '(?:\b[A-Z][a-z]+ )+\(([A-Z]{3,5})\)|(?:\[[^\]]*\])'
 exceptions:
   - API
   - ASCII
+  - AUTO
   - AWS
   - CLI
   - CSS
   - DNS
+  - END
   - FAQ
+  - HOOKS
   - HTML
   - HTTP
   - HTTPS
@@ -37,6 +40,7 @@ exceptions:
   - SHOULD
   - SSH
   - SSL
+  - START
   - TLS
   - TOFU
   - TOML


### PR DESCRIPTION
## Summary

Prod deploys to GitHub Pages have been failing since **2026-04-22** (commit c4ec056). The Vale PR that merged earlier today inherited the breakage and added a second variant of the same class of bug. Both are cases of MDX treating `<` as the start of a JSX element.

## Three fixes

1. **`errors/moat-001.mdx` line 34** — replaced a `<url>` autolink with a bare URL. The angle-bracket autolink form is standard Markdown, but MDX parses `<` as JSX-element-start and chokes on the `/` inside `https://`. This has been the primary deploy blocker for 6 commits.

2. **`content-types/{hooks,index}.mdx`** — removed the `<!-- vale off -->` / `<!-- vale on -->` HTML comments that wrapped the `AUTO-GENERATED:HOOKS-EVENTS` and `AUTO-GENERATED:COMPAT-MATRIX` codegen blocks. MDX parses `<!` as element-start and fails (same class of bug as #1). The wrapped codegen blocks are pure backticked-identifier tables, so Vale doesn't flag them even without suppression.

3. **`vale/styles/Syllago/Acronyms.yml`** — removing the Vale-off markers exposed the codegen-marker text (`AUTO-GENERATED:HOOKS-EVENTS START`, `... END`, etc.) to the `Syllago.Acronyms` rule, which produced 10 spell-out suggestions against the marker tokens. Added `AUTO`, `END`, `HOOKS`, `START` to the exception list — these are code tokens, not acronyms.

## Why CI didn't catch this earlier

The deploy workflow runs on `push` to `main` — i.e., after merge, not on the PR branch — so nothing blocked the merge when the autolink first landed in c4ec056. The `Validate Actions` check we now require was added after c4ec056, and the Vale check was added today and doesn't run `astro build`. Consider adding a `bun run build` step to the Lint workflow on PRs so this class of breakage is caught pre-merge.

## Test plan

- [x] `bun run build` completes locally (311 pages built)
- [x] `bun run lint:vale` reports 0 errors / 0 warnings / 0 suggestions
- [ ] CI `Lint` (Validate Actions + Vale) passes on this PR
- [ ] CI `Deploy to GitHub Pages` passes after merge to `main`
- [ ] Prod site at https://openscribbler.github.io/syllago-docs/ updates with the latest `main` content (including the merged contributing/vouch PR work that hadn't reached prod yet)