### PR TITLE
fix(deploy): unbreak link validation + gate it on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,37 @@ jobs:
           reporter: github-pr-review
           fail_on_error: false
           vale_flags: "--config=.vale.ini"
+
+  build:
+    name: Build
+    needs: validate-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache D2 binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4
+        id: d2-cache
+        with:
+          path: /usr/local/bin/d2
+          key: d2-v0.7.1-linux-amd64
+
+      - name: Install D2
+        run: .github/scripts/install-d2.sh
+
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to the syllago documentation site.
 ### Changed
 - `src/content/docs/index.mdx`, `src/pages/index.astro` — updated landing page tagline from "package manager for AI coding tool content" to "content manager for AI coding tools" (Starlight description + standalone landing `<title>`).
 
+### Fixed
+- `src/content/docs/using-syllago/syllago-yaml.mdx` — removed two broken links to the deleted `syllago create` command. Line 8 now lists only `add` (and "sync content") as the operations that maintain `.syllago.yaml`. Line 141 was rerouted to `syllago loadout create`, which still emits `source: created` per `metadata/backfill.go`.
+- `src/content/docs/using-syllago/collections/library.mdx` — removed the "Create from scratch" subsection. It documented `syllago create skills <name>` and `syllago create rules <name> --provider <slug>`, neither of which exists in syllago 0.10.0+. The remaining content-creation entry points are `syllago add` (from a provider) and `syllago loadout create` (loadouts only).
+- These three references were causing CI link-validation to fail after PR #30 bumped `starlight-links-validator` to a stricter version that catches references to pages the prebuild sync deletes.
+
 ## 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to the syllago documentation site.
 - `src/content/docs/using-syllago/collections/library.mdx` — removed the "Create from scratch" subsection. It documented `syllago create skills <name>` and `syllago create rules <name> --provider <slug>`, neither of which exists in syllago 0.10.0+. The remaining content-creation entry points are `syllago add` (from a provider) and `syllago loadout create` (loadouts only).
 - These three references were causing CI link-validation to fail after PR #30 bumped `starlight-links-validator` to a stricter version that catches references to pages the prebuild sync deletes.
 
+### Added
+- `.github/workflows/lint.yml` — added a `Build` job that runs `bun run build` (which includes `starlight-links-validator`) on every PR. Previously link validation only ran post-merge in `deploy.yml`, which is how the broken `create/` links shipped to main and broke the deploy. The new job mirrors the deploy build steps (Node 22, bun, D2 cache + install, `bun run build`) minus the artifact upload.
+
 ## 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the syllago documentation site.
 
+## 2026-04-28
+
+### Changed
+- `src/content/docs/index.mdx`, `src/pages/index.astro` — updated landing page tagline from "package manager for AI coding tool content" to "content manager for AI coding tools" (Starlight description + standalone landing `<title>`).
+
 ## 2026-04-26
 
 ### Added

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Welcome to syllago
-description: The package manager for AI coding tool content.
+description: The content manager for AI coding tools.
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/using-syllago/collections/library.mdx
+++ b/src/content/docs/using-syllago/collections/library.mdx
@@ -59,22 +59,6 @@ Syllago handles format conversion automatically. A Cursor rule becomes a univers
 
 See `syllago add --help` for full options.
 
-### Create from scratch
-
-Scaffold a new content item with the correct directory structure and metadata template.
-
-```bash
-# Create a new skill
-syllago create skills my-new-skill
-
-# Create a provider-specific rule
-syllago create rules my-rule --provider claude-code
-```
-
-This creates the directory, `.syllago.yaml`, and a starter content file — ready for you to edit.
-
-See [`syllago create`](/using-syllago/cli-reference/create/) for full options.
-
 ## Browsing and inspecting content
 
 ### List content

--- a/src/content/docs/using-syllago/syllago-yaml.mdx
+++ b/src/content/docs/using-syllago/syllago-yaml.mdx
@@ -5,7 +5,7 @@ description: Reference for the .syllago.yaml metadata file that accompanies ever
 
 Every content item in your [library](/using-syllago/collections/library/) has a `.syllago.yaml` file that tracks the item's identity, provenance, and [type](/using-syllago/content-types/) — syllago uses it to manage, inspect, and convert content.
 
-You rarely need to edit `.syllago.yaml` by hand. Syllago generates and maintains it automatically when you [`create`](/using-syllago/cli-reference/create/), [`add`](/using-syllago/cli-reference/add/), or sync content.
+You rarely need to edit `.syllago.yaml` by hand. Syllago generates and maintains it automatically when you [`add`](/using-syllago/cli-reference/add/) or sync content.
 
 ## Field reference
 
@@ -138,7 +138,7 @@ added_at: 2026-03-12T17:16:18Z
 added_by: Holden Hewett
 ```
 
-Content created with [`syllago create`](/using-syllago/cli-reference/create/) sets `source: created` to mark it as locally scaffolded. The `added_by` field records the user who created it.
+Content created with [`syllago loadout create`](/using-syllago/cli-reference/loadout-create/) sets `source: created` to mark it as locally scaffolded. The `added_by` field records the user who created it.
 
 ### Imported from a registry
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const base = '';
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>syllago | The package manager for AI coding tool content</title>
+    <title>syllago | The content manager for AI coding tools</title>
     <meta
       name="description"
       content="Convert, sync, and manage your AI tool configs across Claude Code, Cursor, Windsurf, Copilot, and 7 more providers."


### PR DESCRIPTION
## Summary

Three changes that together unbreak the post-#30 deploy and prevent this class of failure from recurring.

- **docs(landing)** — Rename the landing-page tagline from "package manager for AI coding tool content" to "content manager for AI coding tools." Updates `<title>` in `src/pages/index.astro` and the Starlight `description:` in `src/content/docs/index.mdx`.
- **docs(links)** — Drop three broken references to the deleted `syllago create` command. The CLI dropped `create` in 0.10.0+, the prebuild sync deletes the auto-generated reference page, but two hand-written narrative pages still linked to it. PR #30's `starlight-links-validator` bump caught what the older version missed and broke deploy. Rerouted `syllago-yaml.mdx` line 141 to `syllago loadout create` (which still emits `source: created` per `metadata/backfill.go`); removed the orphaned "Create from scratch" subsection in `library.mdx`.
- **ci(lint)** — Add a `Build` job to `lint.yml` so `starlight-links-validator` runs on every PR. Previously it only ran in `deploy.yml` (gated to main pushes), which is how the broken links shipped to main in the first place. Steps mirror `deploy.yml`'s build job exactly, minus the artifact upload.

## Test plan

- [x] Local `bun run build` from a clean working tree (matching this branch HEAD) — `All internal links are valid.` 315 pages built.
- [ ] CI `Build` job (newly added in this PR) reports green on this PR.
- [ ] After merge, `deploy.yml` build job goes green and GH Pages publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)