### PR TITLE
docs: add Why syllago, Mental Models, Choose Your Path, and Local vs. Global pages

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -406,9 +406,12 @@
 
 ## src/content/docs/getting-started/
 
-- `core-concepts.mdx` — Providers (~1438 tok)
+- `choose-your-path.mdx` — Persona routing: Solo developer / Tech lead / Platform administrator (~700 tok)
+- `core-concepts.mdx` — Providers (with fragmentation-problem framing intro added 2026-05-11) (~1500 tok)
 - `installation.mdx` — System requirements (~678 tok)
+- `mental-models.mdx` — Vocabulary cheat sheet mapping syllago terms to npm/venv/LLVM/etc. (~650 tok)
 - `quick-start.mdx` — Import from your existing tools (~980 tok)
+- `why-syllago.mdx` — Top-of-funnel problem framing: per-provider rules/skills location table + intro to primitives (~800 tok)
 
 ## src/content/docs/moat/
 
@@ -480,6 +483,7 @@
 ## src/content/docs/using-syllago/
 
 - `format-conversion.mdx` — How conversion works (~2337 tok)
+- `local-vs-global.mdx` — Per-project `.syllago/` committed to Git vs per-user `~/.syllago/content/`; side-by-side workflows + decision guide (~900 tok)
 - `syllago-yaml.mdx` — Field reference (~2001 tok)
 - `tui.mdx` — or use the alias (~455 tok)
 

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -954,3 +954,13 @@
 |------|--------|---------|---------|--------|
 | 17:24 | Created design-previews/ — 10 landing-page concept HTML files + iframe gallery index | design-previews/01-spotlight.html through 10-zen.html, design-previews/index.html | 11 self-contained pages, ~2.4k LOC, on-brand Flexoki palette, mouse/cursor effects per concept | ~24k |
 | 17:42 | Combined 01 + 07 into a new preview with hover-revealed ASCII rain and cycling hero phrase (Share/Sync/Ship/Wire/Publish your skills/rules/agents/hooks/commands) | design-previews/11-spotrain.html, design-previews/index.html, .wolf/anatomy.md | New 11th tile added to gallery, originals untouched. Cycle uses textContent + class swap (no innerHTML); rain fades from 0 → 0.10 while body.live | ~3.5k |
+
+## Session: 2026-05-11
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 00:00 | Created 4 new conceptual docs pages from analysisv2 attachment | src/content/docs/getting-started/{why-syllago,mental-models,choose-your-path}.mdx, src/content/docs/using-syllago/local-vs-global.mdx | All link to existing pages (compat/sync-install/install/etc. verified to exist); standard title+description frontmatter matches docsSchema() | ~5k |
+| 00:00 | Updated core-concepts to lead with fragmentation problem framing | src/content/docs/getting-started/core-concepts.mdx | Two-paragraph intro pointing to why-syllago + mental-models, then the original four-concepts treatment | ~0.3k |
+| 00:00 | Added "Who is this for?" persona section to landing page | src/pages/index.astro | Three-card grid between features and provider carousel, deep-linking to choose-your-path anchors; reuses Flexoki palette, mobile-stacks via existing 768px breakpoint | ~2k |
+| 00:00 | Wired new pages into sidebar | sidebar.ts | Getting Started: +why-syllago/mental-models/choose-your-path (top + after Core Concepts). Using Syllago: +local-vs-global (next to Format Conversion) | ~0.4k |
+| 00:00 | Updated CHANGELOG with 2026-05-11 entry | CHANGELOG.md | Added/Changed subsections covering 4 new pages, landing-page section, core-concepts intro, sidebar wiring | ~0.5k |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the syllago documentation site.
 
+## 2026-05-11
+
+### Added
+- `src/content/docs/getting-started/why-syllago.mdx` — new top-of-funnel page that opens with the AI-tool fragmentation problem (per-provider rules/skills location table) and introduces syllago's primitives. Sits at the top of Getting Started before Installation.
+- `src/content/docs/getting-started/mental-models.mdx` — new conceptual page mapping syllago vocabulary (registry, library, loadout, provider, canonical key, hub-and-spoke, privacy gate, MOAT tier) to familiar tools (npm, virtualenv, Vercel, LLVM IR, Sigstore, etc.). Reduces vocabulary overload for new users.
+- `src/content/docs/getting-started/choose-your-path.mdx` — new persona-routing page with three paths: Solo developer (loadouts + TUI), Tech lead / maintainer (committed `.syllago/`, `sync-install` in CI), Platform administrator (private registries, MOAT, sandbox).
+- `src/content/docs/using-syllago/local-vs-global.mdx` — new architecture page explicitly contrasting committed `.syllago/` (per-project, Git-tracked) vs `~/.syllago/content/` (per-user) with side-by-side workflows and a decision guide. Addresses the "syllago is only for global content management" assumption.
+- `src/pages/index.astro` — new "Who is this for?" persona section (3-card grid) between the features grid and provider carousel, deep-linking to the corresponding sections of `choose-your-path`. Mobile-stacks via the existing 768px breakpoint.
+
+### Changed
+- `src/content/docs/getting-started/core-concepts.mdx` — prepended a brief problem-framing intro that points readers to the new `why-syllago` and `mental-models` pages before listing the four formal concepts.
+- `sidebar.ts` — wired three new entries into Getting Started (`why-syllago`, `mental-models`, `choose-your-path`) and one into Using Syllago (`local-vs-global`).
+
 ## 2026-05-08
 
 ### Added

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -7,9 +7,12 @@ export const sidebar: SidebarItem[] = [
   {
     label: 'Getting Started',
     items: [
+      { label: 'Why syllago', slug: 'getting-started/why-syllago' },
       { label: 'Installation', slug: 'getting-started/installation' },
       { label: 'Quick Start', slug: 'getting-started/quick-start' },
       { label: 'Core Concepts', slug: 'getting-started/core-concepts' },
+      { label: 'Mental Models', slug: 'getting-started/mental-models' },
+      { label: 'Choose Your Path', slug: 'getting-started/choose-your-path' },
     ],
   },
   {
@@ -233,6 +236,7 @@ export const sidebar: SidebarItem[] = [
       },
       { label: '.syllago.yaml Format', slug: 'using-syllago/syllago-yaml' },
       { label: 'Format Conversion', slug: 'using-syllago/format-conversion' },
+      { label: 'Local vs. Global', slug: 'using-syllago/local-vs-global' },
     ],
   },
   {

--- a/src/content/docs/getting-started/choose-your-path.mdx
+++ b/src/content/docs/getting-started/choose-your-path.mdx
@@ -1,0 +1,46 @@
+---
+title: Choose Your Path
+description: Pick the route through the docs that matches what you're trying to do.
+---
+
+Syllago serves several different jobs, so the docs are dense enough that it helps to pick a path. Find your role below and follow the suggested route — you can wander into the rest later.
+
+## Solo developer
+
+You manage your own machine. You use one or two AI coding tools, want them in sync, and want to switch contexts between projects (Python work, frontend work, security audits) without retyping the same setup every time.
+
+**Read in order:**
+1. [Install syllago](/getting-started/installation/)
+2. [Quick Start: import from your existing tools](/getting-started/quick-start/)
+3. [Loadouts](/using-syllago/collections/loadouts/) — bundle a "Python stack" or "frontend review" profile and switch with one command
+4. [The TUI](/using-syllago/tui/) — browse, install, and manage content interactively
+
+**Commands you'll lean on:** `syllago init`, `syllago add`, `syllago install`, `syllago loadout create`, `syllago loadout apply --keep`, `syllago loadout remove`.
+
+## Tech lead / maintainer
+
+You own a repo and want every contributor (human or AI) to get the same AI-tool configuration when they clone it. You probably commit `.syllago/` to Git. You want CI to fail if the config drifts.
+
+**Read in order:**
+1. [Local vs. Global architecture](/using-syllago/local-vs-global/) — why and how to commit `.syllago/` to your repo
+2. [`.syllago.yaml` Format](/using-syllago/syllago-yaml/) — the file your team will share
+3. [`syllago sync-install`](/using-syllago/cli-reference/sync-install/) — one command in CI that pulls registries and installs to a provider
+4. [Team setup](/advanced/team-setup/) — multi-developer workflows
+
+**Commands you'll lean on:** `syllago init`, `syllago sync-install --to <provider>`, `syllago compat`, `syllago doctor`.
+
+## Platform administrator
+
+You're standing syllago up for an organization. You need a private registry, signed manifests, and guardrails that prevent internal rules from leaking to public registries.
+
+**Read in order:**
+1. [Registries](/using-syllago/collections/registries/) — how shared content distribution works
+2. [Registry privacy](/advanced/registry-privacy/) — privacy gates and taint propagation
+3. [MOAT trust tiers](/moat/trust-tiers/) — signing, provenance, and trusted roots
+4. [Sandbox](/advanced/sandbox/) — running AI providers under bubblewrap restrictions
+
+**Commands you'll lean on:** `syllago registry create`, `syllago manifest generate`, `syllago moat sign`, `syllago moat trust`, `syllago sandbox`.
+
+## Not sure which fits?
+
+If you're evaluating syllago for the first time, the solo-developer path is the shortest route to a working setup. The other roles build on top of that foundation — you can pick them up later as your needs grow.

--- a/src/content/docs/getting-started/core-concepts.mdx
+++ b/src/content/docs/getting-started/core-concepts.mdx
@@ -3,7 +3,9 @@ title: Core Concepts
 description: How syllago works — providers, content types, collections, and format conversion.
 ---
 
-syllago manages AI coding tool content across multiple providers. This page covers the four concepts you need to understand how everything fits together: **providers**, **content types**, **collections**, and **format conversion**.
+Every AI coding tool wants its rules, skills, and configs in a different format, in a different place. Syllago is the layer that lets you maintain one canonical copy of each item and convert it on the fly to whichever tool needs it. For a longer treatment of the problem, see [Why syllago](/getting-started/why-syllago/); for analogies to package managers and virtualenvs, see [Mental Models](/getting-started/mental-models/).
+
+This page covers the four concepts that make the rest of the docs make sense: **providers**, **content types**, **collections**, and **format conversion**.
 
 ## Providers
 

--- a/src/content/docs/getting-started/mental-models.mdx
+++ b/src/content/docs/getting-started/mental-models.mdx
@@ -12,11 +12,11 @@ Syllago borrows ideas from package managers, virtual environments, build tools, 
 | **[Registry](/using-syllago/collections/registries/)** | npm registry, Homebrew tap, `apt` source | A networked source of installable content that someone else maintains. |
 | **[Library](/using-syllago/collections/library/)** | `~/.npm/`, `~/.cargo/`, your local dotfiles | The on-machine store of content you own and edit. |
 | **[Loadout](/using-syllago/collections/loadouts/)** | Python `venv`, `docker-compose.yml`, a Terraform workspace | A named bundle you apply as a unit and revert cleanly. |
-| **[Provider](/using-syllago/providers/)** | A deploy target (Vercel, ECR, Heroku) | The thing your content ships to — `--to <provider>` is the destination. |
+| **[Provider](/using-syllago/providers/)** | A deploy target (Vercel, Netlify, Heroku) | The thing your content ships to — `--to <provider>` is the destination. |
 | **[Content type](/using-syllago/content-types/)** | A package or artifact format | The kind of thing (rule, skill, agent, hook…). Each type has its own conventions. |
 | **[Canonical key](/reference/canonical-keys/)** | An interface, or a portable IR | The tool-neutral name for a capability (e.g. `hierarchical_loading`) that providers implement differently. |
 | **[Format conversion](/using-syllago/format-conversion/)** | A transpiler (Babel, esbuild target) | What syllago does between its internal representation and each provider's native format. |
-| **Hub-and-spoke model** | LLVM IR, GraphQL between front and back ends | One neutral middle format; providers connect through it instead of converting pairwise. |
+| **Hub-and-spoke model** | A compiler's intermediate representation, GraphQL between front and back ends | One neutral middle format; providers connect through it instead of converting pairwise. |
 | **[Privacy gate](/advanced/registry-privacy/)** | A `.gitignore` for AI content | A guard that stops marked-private content from leaking to public registries. |
 | **[MOAT trust tier](/moat/trust-tiers/)** | Sigstore, npm provenance attestation | The signed-and-verified provenance level of a registry. |
 | **[Sandbox](/advanced/sandbox/)** | Docker, bubblewrap, an unprivileged user | A confined environment for running an AI provider with restricted FS, network, and env access. |

--- a/src/content/docs/getting-started/mental-models.mdx
+++ b/src/content/docs/getting-started/mental-models.mdx
@@ -1,0 +1,36 @@
+---
+title: Mental Models
+description: If syllago's vocabulary feels new, map each term to a tool you already know.
+---
+
+Syllago borrows ideas from package managers, virtual environments, build tools, and version control. If a word feels unfamiliar, the chances are good you already have a working mental model from somewhere else.
+
+## Vocabulary cheat sheet
+
+| Syllago term | Familiar analog | Why it's similar |
+|--------------|-----------------|------------------|
+| **[Registry](/using-syllago/collections/registries/)** | npm registry, Homebrew tap, `apt` source | A networked source of installable content that someone else maintains. |
+| **[Library](/using-syllago/collections/library/)** | `~/.npm/`, `~/.cargo/`, your local dotfiles | The on-machine store of content you own and edit. |
+| **[Loadout](/using-syllago/collections/loadouts/)** | Python `venv`, `docker-compose.yml`, a Terraform workspace | A named bundle you apply as a unit and revert cleanly. |
+| **[Provider](/using-syllago/providers/)** | A deploy target (Vercel, ECR, Heroku) | The thing your content ships to — `--to <provider>` is the destination. |
+| **[Content type](/using-syllago/content-types/)** | A package or artifact format | The kind of thing (rule, skill, agent, hook…). Each type has its own conventions. |
+| **[Canonical key](/reference/canonical-keys/)** | An interface, or a portable IR | The tool-neutral name for a capability (e.g. `hierarchical_loading`) that providers implement differently. |
+| **[Format conversion](/using-syllago/format-conversion/)** | A transpiler (Babel, esbuild target) | What syllago does between its internal representation and each provider's native format. |
+| **Hub-and-spoke model** | LLVM IR, GraphQL between front and back ends | One neutral middle format; providers connect through it instead of converting pairwise. |
+| **[Privacy gate](/advanced/registry-privacy/)** | A `.gitignore` for AI content | A guard that stops marked-private content from leaking to public registries. |
+| **[MOAT trust tier](/moat/trust-tiers/)** | Sigstore, npm provenance attestation | The signed-and-verified provenance level of a registry. |
+| **[Sandbox](/advanced/sandbox/)** | Docker, bubblewrap, an unprivileged user | A confined environment for running an AI provider with restricted FS, network, and env access. |
+
+## When you'd reach for each one
+
+- Trying things out on your own machine? **Library** + `install`.
+- Need a coworker to use the same content? **Registry** (or commit `.syllago/` to the repo — see [Local vs. Global](/using-syllago/local-vs-global/)).
+- Want to switch between a "Python backend" and a "frontend review" context? **Loadout**.
+- Targeting a tool other than the one you authored in? **Format conversion** runs automatically on install.
+- Asking "will this work in Kiro?" Run [`syllago compat`](/using-syllago/cli-reference/compat/).
+
+## Related
+
+- [Why syllago](/getting-started/why-syllago/) — the problem these models exist to solve.
+- [Core Concepts](/getting-started/core-concepts/) — the formal definitions.
+- [Format Conversion](/using-syllago/format-conversion/) — how the hub-and-spoke model works in practice.

--- a/src/content/docs/getting-started/why-syllago.mdx
+++ b/src/content/docs/getting-started/why-syllago.mdx
@@ -1,0 +1,52 @@
+---
+title: Why syllago
+description: AI coding tools don't agree on anything. Syllago is the content manager that makes them work as one.
+---
+
+If you've worked with more than one AI coding tool, you've felt this: each one wants its rules, skills, and configuration in a slightly different place, in a slightly different format. None of them know about the others. Sharing context across them is manual, fragile, and easy to get wrong.
+
+Syllago exists to fix that.
+
+## The fragmentation problem
+
+A typical workflow today might involve **Claude Code** in the terminal, **Cursor** as the IDE, and **Copilot CLI** for shell commands. Each describes the same thing differently:
+
+| Tool | Rules go in… | Skills go in… |
+|------|--------------|---------------|
+| Claude Code | `CLAUDE.md`, `.claude/` | `.claude/skills/` |
+| Cursor | `.cursorrules`, `.cursor/rules/*.mdc` | (no native equivalent) |
+| Windsurf | `.windsurfrules`, `.windsurf/rules/` | `.windsurf/workflows/` |
+| Copilot CLI | `.github/copilot-instructions.md` | (no native equivalent) |
+| Kiro | `.kiro/steering/` | (no native equivalent) |
+
+Add **Roo Code**, **Cline**, **Amp**, **Gemini CLI**, **Codex**, **OpenCode**, **Zed**, **Factory Droid**, **Crush**, and **Pi**, and the table grows in every dimension. MCP servers compound it — each client wires them up its own way.
+
+Without a manager, every team that uses more than one tool ends up with the same workarounds: shell scripts that copy files between locations, README sections explaining where to paste which thing, configuration drift between teammates who use different tools, broken toolchains when a provider renames a directory.
+
+## What syllago does
+
+Syllago is a content manager for AI coding tools — think `apt`, `brew`, or `npm`, but for AI-assistant configuration. You maintain one canonical copy of each item. Syllago layers three things on top:
+
+1. **Conversion.** When you install a skill to Cursor, syllago translates it into a Cursor-compatible rule. The same skill installed to Kiro becomes a steering file. Intent carries forward; format adapts. See [Format Conversion](/using-syllago/format-conversion/).
+2. **Compatibility checking.** [`syllago compat`](/using-syllago/cli-reference/compat/) reports which providers can fully consume an item and where features will degrade in translation, so you know before you publish.
+3. **Distribution.** Git-based [registries](/using-syllago/collections/registries/) let you publish org-wide standards and pull updates with one command. [Loadouts](/using-syllago/collections/loadouts/) bundle related items so you apply a whole stack as a unit and revert it cleanly.
+
+## What you actually manage
+
+Syllago breaks AI-tool configuration into a small set of tool-agnostic primitives:
+
+- **[Rules](/using-syllago/content-types/rules/)** — Markdown instructions governing style, architecture, and behavior.
+- **[Skills](/using-syllago/content-types/skills/)** — Multi-file workflow packages the AI can call to perform actions.
+- **[Agents](/using-syllago/content-types/agents/)** — Persona and steering definitions for the model.
+- **[MCP Configs](/using-syllago/content-types/mcp-configs/)** — Provider-agnostic settings for Model Context Protocol servers.
+- **[Hooks](/using-syllago/content-types/hooks/)** — Event listeners that trigger behavior on local events.
+- **[Commands](/using-syllago/content-types/commands/)** — Custom slash commands.
+
+You define each item once. Syllago decides what to do with it on each provider.
+
+## Where to go next
+
+- New to syllago? [Install it](/getting-started/installation/) and run the [Quick Start](/getting-started/quick-start/).
+- Want the formal model? [Core Concepts](/getting-started/core-concepts/).
+- Vocabulary feels unfamiliar? [Mental Models](/getting-started/mental-models/) maps every term to a tool you probably already know.
+- Looking for the path that matches your role? [Choose your path](/getting-started/choose-your-path/).

--- a/src/content/docs/using-syllago/local-vs-global.mdx
+++ b/src/content/docs/using-syllago/local-vs-global.mdx
@@ -1,0 +1,81 @@
+---
+title: Local vs. Global
+description: Syllago works at the project level (committed to Git) or at the user level (shared across all your work). You don't have to pick one.
+---
+
+A common assumption about syllago is that it's only useful for org-wide content management — shared registries, cross-team standards, networked distribution. That's one mode. But syllago is equally happy as a local, repo-scoped tool whose state lives next to your code.
+
+The right question isn't "local or global?" It's "where does this particular piece of content belong?"
+
+## The two surfaces
+
+|  | **Local (per-project)** | **Global (per-user)** |
+|---|---|---|
+| Source of truth | `.syllago/` committed to the repo | `~/.syllago/content/` on your machine |
+| Who sees it | Anyone who clones the repo | Just you |
+| Survives a fresh checkout? | Yes | No (re-acquire from a registry) |
+| Best for | Project-specific rules, team standards, CI gates | Personal preferences, cross-project skills |
+| Created by | `syllago init` in the repo root | First `syllago add` from any provider |
+
+The two coexist. A given project's AI-tool setup can pull from both: project-specific rules from the local `.syllago/` directory, plus personal skills from your global library.
+
+## The local-only project
+
+```bash
+# In a project where you want config to ride with the repo
+cd my-project
+syllago init
+syllago add --from claude-code        # capture what you've already configured
+git add .syllago
+git commit -m "chore: scaffold syllago for this repo"
+```
+
+From there, anyone who clones the repo runs `syllago sync-install --to <their-provider>` and gets the same rules, skills, and MCP configs the team agreed on. No network calls to a registry, no `~/.syllago/`-state assumptions about each contributor's machine.
+
+This is the right mode for:
+
+- Style and architecture rules that only apply to *this* repo
+- Skills and hooks specific to the project's stack
+- Onboarding new contributors with a single `git clone`
+
+## The global / shared mode
+
+```bash
+# Add a team registry, sync it, install to your provider of choice
+syllago registry add https://github.com/org/ai-standards.git
+syllago registry sync
+syllago install team/python-rules --to claude-code
+```
+
+A registry is a Git repo of syllago content. Adding it makes its items available across every project on your machine. You can pull individual items into any project or apply a whole loadout from it.
+
+This is the right mode for:
+
+- Org-wide rules that should follow you between repos
+- Curated community collections
+- Distributing a polished "starter pack" of AI-tool configuration
+
+## Mixing the two
+
+In practice most teams use both. The split usually looks like:
+
+- **Repo-local `.syllago/`** holds rules and hooks specific to *this* codebase — style guides, build commands, file-layout conventions.
+- **Global registries** hold widely-reusable content — generic skills, security checklists, language-specific best practices.
+
+A project can override a registry item by keeping its own copy in `.syllago/`. Local content takes precedence over registry content with the same name.
+
+## Quick decision guide
+
+| If you want to… | Reach for… |
+|---|---|
+| Ship one repo's AI config to every contributor | Local `.syllago/`, committed |
+| Share content across many repos you own | Global library |
+| Distribute content across an org or team | Git registry |
+| Lock down what can or can't leave the org | Private registry + [privacy gate](/advanced/registry-privacy/) |
+| Apply a curated set of content as a unit | [Loadout](/using-syllago/collections/loadouts/) on top of either surface |
+
+## Related
+
+- [Collections overview](/using-syllago/collections/) — library, registries, and loadouts
+- [`.syllago.yaml` Format](/using-syllago/syllago-yaml/) — the shared file format
+- [Team setup](/advanced/team-setup/) — applying these patterns at scale

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -279,6 +279,75 @@ const base = '';
         line-height: 1.5;
       }
 
+      /* ── Personas ── */
+      .personas {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1rem 1.5rem 3rem;
+      }
+
+      .personas-header {
+        text-align: center;
+        margin-bottom: 2rem;
+      }
+
+      .personas-header h2 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+      }
+
+      .personas-header p {
+        font-size: 0.95rem;
+        color: var(--text-muted);
+      }
+
+      .personas-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1.5rem;
+      }
+
+      .persona-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.5rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        background: var(--bg-secondary);
+        transition: border-color 0.15s, transform 0.15s;
+        color: var(--text);
+      }
+
+      .persona-card:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
+        color: var(--text);
+      }
+
+      .persona-card h3 {
+        font-size: 1.05rem;
+        font-weight: 700;
+      }
+
+      .persona-card p {
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        line-height: 1.5;
+        flex-grow: 1;
+      }
+
+      .persona-link {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      .persona-card:hover .persona-link {
+        color: var(--accent-hover);
+      }
+
       /* ── Provider Carousel ── */
       .providers {
         max-width: 960px;
@@ -462,7 +531,8 @@ const base = '';
 
       /* ── Responsive ── */
       @media (max-width: 768px) {
-        .features-grid {
+        .features-grid,
+        .personas-grid {
           grid-template-columns: 1fr;
           gap: 1.5rem;
         }
@@ -571,6 +641,43 @@ const base = '';
             the same content from the same source.
           </p>
         </div>
+      </div>
+    </section>
+
+    <!-- Personas -->
+    <section class="personas">
+      <div class="personas-header">
+        <h2>Who is this for?</h2>
+        <p>Syllago serves several jobs. Pick the path that matches what you're doing right now.</p>
+      </div>
+      <div class="personas-grid">
+        <a class="persona-card" href={base + '/getting-started/choose-your-path/#solo-developer'}>
+          <h3>Solo developer</h3>
+          <p>
+            You use one or two AI tools and want them in sync. Switch between
+            "Python stack" and "frontend review" contexts in one command with
+            loadouts and the TUI.
+          </p>
+          <span class="persona-link">Solo developer path &rarr;</span>
+        </a>
+        <a class="persona-card" href={base + '/getting-started/choose-your-path/#tech-lead--maintainer'}>
+          <h3>Tech lead / maintainer</h3>
+          <p>
+            You want every contributor cloning your repo to get the same AI
+            config. Commit <code>.syllago/</code>, run <code>syllago sync-install</code> in
+            CI, and keep the team from drifting.
+          </p>
+          <span class="persona-link">Tech lead path &rarr;</span>
+        </a>
+        <a class="persona-card" href={base + '/getting-started/choose-your-path/#platform-administrator'}>
+          <h3>Platform admin</h3>
+          <p>
+            You're rolling syllago out across an organization. Private
+            registries, signed manifests, privacy gates, and sandboxed
+            providers — without internal rules leaking out.
+          </p>
+          <span class="persona-link">Platform admin path &rarr;</span>
+        </a>
       </div>
     </section>
 


### PR DESCRIPTION
Addresses the four conceptual gaps identified in the analysisv2 doc: the
"why syllago exists" problem framing, the local-vs-global architecture
story, a mental-models translation layer, and persona-based routing.

- New: getting-started/why-syllago — opens with the fragmentation problem
  (per-provider rules/skills location table) and introduces primitives.
- New: getting-started/mental-models — maps syllago vocabulary (registry,
  library, loadout, provider, canonical key, hub-and-spoke, privacy gate,
  MOAT tier) to familiar tools (npm, virtualenv, LLVM IR, Sigstore).
- New: getting-started/choose-your-path — persona routes for solo dev,
  tech lead/maintainer, and platform administrator.
- New: using-syllago/local-vs-global — contrasts committed .syllago/ vs
  per-user library, with side-by-side workflows and a decision guide.
- Changed: getting-started/core-concepts — prepended brief problem-framing
  intro pointing to the new why-syllago and mental-models pages.
- Changed: src/pages/index.astro — added "Who is this for?" persona
  section (3-card grid) between the features grid and provider carousel,
  deep-linking to choose-your-path anchors.
- Changed: sidebar.ts — wired all four new pages into the sidebar.

https://claude.ai/code/session_012uEGvFreiu7w4LAAwK7bwZ