### PR TITLE
Docs sprint follow-up: Quick Start fixes, llms.txt provider gap, first how-to guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the syllago documentation site.
 
+## 2026-07-09
+
+### Added
+- `src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx` — new task-based guide: import rules from Claude Code and install them into Cursor, with dry-run preview, verification steps, and an explanation of the Markdown→MDC conversion (#42).
+- `src/content/docs/using-syllago/how-to/install-community-skill.mdx` — new task-based guide: add a public registry, browse skills, and install one into Claude Code, including a MOAT trust-on-first-use note and verification steps (#46).
+- `src/content/docs/for-ai-assistants.mdx` — new "Verify it worked" section with a provider-list smoke-test question, so readers can confirm their AI assistant actually absorbed the llms.txt context (#56).
+
+### Changed
+- `src/content/docs/getting-started/quick-start.mdx` — restructured from Write the Docs Portland stress-test feedback (#54, #55, #38): Installation prerequisite callout at the top; anchor links on the two paths; "follow the terminal prompts" cue with multi-select key hints and an explanation of the "no project markers found" warning; registry section now explains that registries are user-created git repos (with a pointer to `registry create`); the fake `team/ai-configs` example URL replaced with the official OpenScribbler meta-registry; install step moved ahead of `syllago list` so readers reach the payoff sooner.
+- `sidebar.ts` — new "How-to Guides" group under Using Syllago with the two new guides.
+- `astro.config.mjs` — `starlight-llms-txt` now promotes the provider support matrix to the top of `llms-full.txt` so AI assistants can surface the provider list (#56).
+
+### Fixed
+- `src/content/docs/advanced/team-setup.mdx` — two references to the removed `syllago sync-and-export` command updated to `syllago sync-install`.
+- `src/content/docs/using-syllago/content-types/rules.mdx` — "Creating a rule" section referenced the removed `syllago create` command; now documents importing a rule file via `syllago add rules --from ./my-rule.md`.
+- `src/content/docs/using-syllago/syllago-yaml.mdx` — two field descriptions referenced the removed `syllago create` command; reworded to "scaffolded locally". `bun run lint:cli-refs` is clean again.
+
 ## 2026-05-11
 
 ### Added

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,7 +45,13 @@ const integrations = [
         errorOnLocalLinks: false,
         exclude: ['/using-syllago/providers/*', '/using-syllago/providers/*/*'],
       }),
-      starlightLlmsTxt(),
+      starlightLlmsTxt({
+        // Keep the provider support matrix near the top of llms-full.txt so
+        // AI assistants can answer "which providers does syllago support?"
+        // without shelling out to `syllago info providers` (#56). Both id
+        // spellings listed to survive Astro id-shape changes.
+        promote: ['index*', 'using-syllago/providers', 'using-syllago/providers/index*'],
+      }),
       starlightLlmActions({
         // syllago-docs already publishes per-page markdown via
         // `src/pages/[...slug].md.ts` (which uses entryToSimpleMarkdown

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -20,6 +20,14 @@ export const sidebar: SidebarItem[] = [
     items: [
       { label: 'The TUI', slug: 'using-syllago/tui' },
       {
+        label: 'How-to Guides',
+        collapsed: true,
+        items: [
+          { label: 'Claude Code rules into Cursor', slug: 'using-syllago/how-to/claude-code-rules-to-cursor' },
+          { label: 'Install a community skill', slug: 'using-syllago/how-to/install-community-skill' },
+        ],
+      },
+      {
         label: 'CLI Reference',
         collapsed: true,
         items: cliSidebarItems as SidebarItem[],

--- a/src/content/docs/advanced/team-setup.mdx
+++ b/src/content/docs/advanced/team-setup.mdx
@@ -110,7 +110,7 @@ This is separate from registry content. The registry holds the **what** (rules, 
 
 ## CI/CD integration
 
-Use `syllago sync-and-export` or `syllago install` in CI pipelines to automate content distribution. The `--json` flag produces machine-readable output suitable for scripting:
+Use `syllago sync-install` or `syllago install` in CI pipelines to automate content distribution. The `--json` flag produces machine-readable output suitable for scripting:
 
 ```bash
 syllago install --to claude-code --json
@@ -123,7 +123,7 @@ Examples of CI use cases:
 syllago install --to cursor --type skills --json
 
 # Sync registries and install in one step
-syllago sync-and-export --to claude-code --json
+syllago sync-install --to claude-code --json
 
 # Install only rules
 syllago install --to claude-code --type rules --json

--- a/src/content/docs/for-ai-assistants.mdx
+++ b/src/content/docs/for-ai-assistants.mdx
@@ -36,3 +36,17 @@ curl -s https://syllago.dev/llms-full.txt | pbcopy
 - Use `llms-small.txt` when you just need an overview or are working with smaller context windows
 - Use `llms-full.txt` when you need detailed information about specific features
 - The **Copy page** button (top-right of any page) copies individual page content for focused questions
+
+## Verify it worked
+
+After feeding the docs to your assistant, ask it a question whose answer lives in the docs — not in the model's general knowledge. A good smoke test:
+
+> Which providers does syllago support, and which of them support skills?
+
+The answer should list the providers from the [provider support matrix](/using-syllago/providers/) (Claude Code, Cursor, Gemini CLI, Windsurf, Codex, Copilot CLI, Zed, Cline, Roo Code, OpenCode, Kiro, Amp, Factory Droid, Pi, Crush) rather than guessing or telling you to run a command. If the assistant can't answer, it likely didn't receive the full file — try `llms-full.txt` rather than `llms-small.txt`, or paste the provider matrix page directly using its **Copy page** button.
+
+You can always get the authoritative list locally with:
+
+```bash
+syllago info providers
+```

--- a/src/content/docs/getting-started/quick-start.mdx
+++ b/src/content/docs/getting-started/quick-start.mdx
@@ -3,12 +3,18 @@ title: Quick Start
 description: Get up and running with syllago in under five minutes.
 ---
 
-This guide covers two paths to get started with syllago:
+import { Aside } from '@astrojs/starlight/components';
 
-1. **Import from your existing tools** — pull in rules, skills, or context you already have configured in an AI coding tool
-2. **Browse a registry** — discover and install shared content from a team or community registry
+In the next five minutes you'll move real content between AI coding tools — no manual format conversion, no copy-pasting config files.
 
-Both paths start with `syllago init`.
+<Aside type="note" title="Prerequisite">
+Install syllago first — see [Installation](/getting-started/installation/). Verify it's on your PATH with `syllago version`.
+</Aside>
+
+There are two paths to get started, depending on what you have today:
+
+1. [**Import from your existing tools**](#import-from-your-existing-tools) — pull in rules, skills, or context you already have configured in an AI coding tool
+2. [**Browse a registry**](#browse-a-registry) — discover and install shared content from a team or community registry
 
 ## Import from your existing tools
 
@@ -20,7 +26,11 @@ If you already have AI coding tools configured (Claude Code rules, Cursor rules,
 syllago init
 ```
 
-This detects AI coding tools (providers) on your machine and creates your config at `.syllago/config.json`. Follow the interactive prompts, or pass `--yes` to accept defaults.
+Follow the terminal prompts: `init` detects the AI coding tools (providers) on your machine and asks you to confirm which ones to manage. In the provider picker, **space** toggles a selection and **enter** confirms. When it finishes, your config exists at `.syllago/config.json`. To skip the prompts and accept defaults, pass `--yes`.
+
+<Aside type="tip">
+If you're running in an empty or brand-new directory, you may see `Warning: no project markers found (go.mod, package.json, etc.)`. That's expected — syllago just couldn't detect a project type, so it uses the current directory. It's safe to continue.
+</Aside>
 
 ### Discover available content
 
@@ -46,6 +56,19 @@ Content is copied into your library (`~/.syllago/content/`), where syllago manag
 
 > **Tip:** Use `--dry-run` to preview what would be written without making changes. Use `--all` to add everything at once.
 
+### Install to another provider
+
+```bash
+syllago install my-rule --to cursor
+```
+
+That's the payoff: the item moves from your library into Cursor's expected location, with the format converted automatically. By default, syllago uses a **symlink** so changes stay in sync. Pass `--method copy` if you need a standalone file.
+
+```bash
+# Preview what would happen without writing anything
+syllago install my-rule --to cursor --dry-run
+```
+
 ### See what you have
 
 ```bash
@@ -54,24 +77,9 @@ syllago list
 
 Output is grouped by type (rules, skills, agents, etc.). Use `--source` to filter by origin and `--type` to filter by content type.
 
-### Install to another provider
-
-```bash
-syllago install my-rule --to cursor
-```
-
-This installs the item from your library into Cursor's expected location, converting the format automatically. By default, syllago uses a **symlink** so changes stay in sync. Pass `--method copy` if you need a standalone file.
-
-```bash
-# Preview what would happen without writing anything
-syllago install my-rule --to cursor --dry-run
-```
-
-That's it — you've moved content from one AI coding tool to another with format conversion handled for you.
-
 ## Browse a registry
 
-Registries are git-based repos of shared content. Use them to pull in team standards, community collections, or curated configurations.
+Registries are git repos of shared content — team standards, community collections, curated configurations. A registry isn't a central remote service: it's an ordinary git repository that someone creates and publishes. You can add any registry you have the URL for, or [create your own](/using-syllago/cli-reference/registry-create/) with `syllago registry create`.
 
 ### Initialize syllago
 
@@ -81,10 +89,14 @@ Skip this if you already ran it above.
 syllago init
 ```
 
+Follow the terminal prompts to confirm the detected providers.
+
 ### Add a registry
 
+The example below uses the official [syllago meta-registry](https://github.com/OpenScribbler/syllago-meta-registry) — swap in your team's registry URL if you have one.
+
 ```bash
-syllago registry add https://github.com/team/ai-configs.git
+syllago registry add https://github.com/OpenScribbler/syllago-meta-registry.git
 ```
 
 You can optionally pass `--name` to give it a short alias, or `--ref` to pin a specific branch or tag.

--- a/src/content/docs/using-syllago/content-types/rules.mdx
+++ b/src/content/docs/using-syllago/content-types/rules.mdx
@@ -126,11 +126,13 @@ Use strict TypeScript with explicit return types.
 
 ### Creating a rule
 
+Write your rule as a markdown file, then import it:
+
 ```bash
-syllago create rules my-rule --provider claude-code
+syllago add rules --from ./my-rule.md
 ```
 
-This scaffolds a new rule directory under `local/` with template files and `.syllago.yaml` metadata.
+When `--from` points at a file instead of a provider, syllago imports it into your library with `.syllago.yaml` metadata. You can also author the rule directly in your library — see [Library](/using-syllago/collections/library/) for the directory layout.
 
 ### Importing from a provider
 

--- a/src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx
+++ b/src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx
@@ -1,0 +1,67 @@
+---
+title: Get your Claude Code rules into Cursor
+description: Import rules from Claude Code into your syllago library and install them into Cursor, with format conversion handled automatically.
+---
+
+You have rules configured in Claude Code and want the same guidance in Cursor — without maintaining two copies by hand. This guide moves them through syllago in four commands.
+
+## What you need
+
+- syllago [installed](/getting-started/installation/) and initialized (`syllago init`)
+- Claude Code with at least one rule configured (`CLAUDE.md` or `.claude/` rules)
+
+## 1. See what Claude Code has
+
+```bash
+syllago add --from claude-code
+```
+
+Without a positional argument, `add` runs in discovery mode: it lists the content Claude Code has available without importing anything.
+
+## 2. Import the rules into your library
+
+```bash
+# Import all rules
+syllago add rules --from claude-code
+
+# Or import one specific rule
+syllago add rules/security --from claude-code
+```
+
+The rules are copied into your library (`~/.syllago/content/`), where syllago manages them independently of Claude Code. Run `syllago list` to confirm what landed.
+
+## 3. Preview the install
+
+```bash
+syllago install security --to cursor --dry-run
+```
+
+`--dry-run` shows exactly what would be written to Cursor's directories without touching anything. Nothing changes until you run the command without the flag.
+
+## 4. Install to Cursor
+
+```bash
+syllago install security --to cursor
+```
+
+By default syllago installs a **symlink**, so future edits to the rule in your library show up in Cursor immediately. Pass `--method copy` if you want a standalone file instead.
+
+## 5. Verify it worked
+
+Look in your project's `.cursor/rules/` directory — you should see the rule as an `.mdc` file:
+
+```bash
+ls .cursor/rules/
+```
+
+Open Cursor and the rule is active. You can also confirm syllago's view of the install with `syllago list`.
+
+## What syllago converted for you
+
+Claude Code stores rules as plain Markdown; Cursor expects **MDC** format (`.mdc` files with metadata frontmatter like `description`, `alwaysApply`, and `globs`). syllago performs that conversion automatically during install — the copy in your library stays in canonical form, so the same rule can also be installed to any other provider. See [Format Conversion](/using-syllago/format-conversion/) for the details.
+
+## Related
+
+- [Cursor provider reference](/using-syllago/providers/cursor/) — file locations and capability details
+- [`syllago add`](/using-syllago/cli-reference/add/) and [`syllago install`](/using-syllago/cli-reference/install/) — full flag reference
+- [Rules](/using-syllago/content-types/rules/) — how syllago models rules across providers

--- a/src/content/docs/using-syllago/how-to/install-community-skill.mdx
+++ b/src/content/docs/using-syllago/how-to/install-community-skill.mdx
@@ -1,0 +1,65 @@
+---
+title: Install a community skill into Claude Code
+description: Discover a skill in a public syllago registry and install it into Claude Code.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This is syllago's "download a plugin" experience: find a skill someone else published, install it into Claude Code, and start using it — no manual file copying.
+
+## What you need
+
+- syllago [installed](/getting-started/installation/) and initialized (`syllago init`)
+- Claude Code installed
+
+## 1. Add a public registry
+
+A [registry](/using-syllago/collections/registries/) is a git repo of shared content. The example uses the official [syllago meta-registry](https://github.com/OpenScribbler/syllago-meta-registry):
+
+```bash
+syllago registry add https://github.com/OpenScribbler/syllago-meta-registry.git
+```
+
+<Aside type="note">
+If syllago asks you to confirm trust for the registry on first use, review the prompt and accept — this is MOAT's trust-on-first-use check. See [Trust tiers](/moat/trust-tiers/) for how registry trust works.
+</Aside>
+
+## 2. Sync it
+
+```bash
+syllago registry sync
+```
+
+This pulls the registry's latest content into a local clone. Syncing never modifies your library or your providers — it only updates what's available to browse.
+
+## 3. Browse the available skills
+
+```bash
+syllago registry items --type skills
+```
+
+This lists every skill across your registries. Pick one that looks useful — the examples below use a skill named `changelog-writer`; substitute the name you actually chose.
+
+## 4. Install it into Claude Code
+
+```bash
+syllago install changelog-writer --to claude-code
+```
+
+syllago resolves the skill from the registry, converts it to Claude Code's format, and symlinks it into place. Add `--dry-run` first if you want to see what would be written before committing.
+
+## 5. Verify and use it
+
+Claude Code reads skills from `~/.claude/skills/` (global) and `.claude/skills/` in a project. Confirm the install:
+
+```bash
+ls ~/.claude/skills/
+```
+
+Then start a Claude Code session and ask it to use the skill by name — Claude also invokes skills automatically when a task matches the skill's description.
+
+## Related
+
+- [Skills](/using-syllago/content-types/skills/) — how syllago models skills across providers
+- [Claude Code provider reference](/using-syllago/providers/claude-code/skills/) — file locations and capability details
+- [`syllago registry`](/using-syllago/cli-reference/registry/) — full registry command reference

--- a/src/content/docs/using-syllago/syllago-yaml.mdx
+++ b/src/content/docs/using-syllago/syllago-yaml.mdx
@@ -33,7 +33,7 @@ These fields record where the content came from. They're populated when syllago 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `source` | string | Discriminator for the source kind. `created` means the item was scaffolded locally via `syllago create`; otherwise unset for imported content. |
+| `source` | string | Discriminator for the source kind. `created` means the item was scaffolded locally; otherwise unset for imported content. |
 | `source_provider` | string | Provider slug content was imported from (e.g. `claude-code`). |
 | `source_format` | string | Original file format (e.g. `md`, `mdc`, `json`, `toml`). |
 | `source_type` | string | How the content was acquired. One of: `git`, `filesystem`, `registry`, `provider`. |
@@ -63,7 +63,7 @@ Set on add to track where the content lives.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `created_at` | string (ISO 8601) | When the item was scaffolded via `syllago create`. |
+| `created_at` | string (ISO 8601) | When the item was scaffolded locally. |
 | `added_at` | string (ISO 8601) | When the item was added to the library. |
 | `added_by` | string | Who or what added the item — e.g. `syllago v0.9.0`, or a person's name. |
 


### PR DESCRIPTION
## Summary

Executes the highest-priority open issues from the WTD Portland sprint backlog:

- **Quick Start rewrite (#54, #55, #38)** — Installation prerequisite callout at the top; anchor links on the two paths; removed the redundant "Both paths start with `syllago init`" sentence; "follow the terminal prompts" cue with the multi-select key hints (space toggles, enter confirms) and an aside explaining the "no project markers found" warning; registry section now explains registries are user-created git repos (with a pointer to `registry create`); the fake `team/ai-configs` example URL replaced with the official OpenScribbler meta-registry; install step moved ahead of `syllago list` so readers reach the payoff sooner.
- **llms.txt provider gap (#56)** — `starlight-llms-txt` now promotes the provider support matrix to the second position in `llms-full.txt` (verified in the built output), and the For AI Assistants page gains a "Verify it worked" section with a provider-list smoke-test question.
- **First how-to guides (#42, #46)** — new `using-syllago/how-to/` section with *Get your Claude Code rules into Cursor* and *Install a community skill into Claude Code*, wired into the sidebar. All commands verified against the CLI reference pages.
- **Drive-by fix** — five pre-existing stale CLI references (`sync-and-export` → `sync-install`; removed `syllago create`) that were failing `bun run lint:cli-refs`; the linter is clean again.

Closes #54. Closes #55. Closes #56. Closes #42. Closes #46.
(#38 intentionally not auto-closed — see comment there.)

## Bead

N/A

## Checklist

- [x] `bun run build` (built via `astro build` — 322 pages, all internal links valid; prebuild sync intentionally skipped to avoid unrelated generated churn)
- [x] `bun run lint:cli-refs` (clean — was failing with 5 pre-existing findings, now fixed)
- [x] Vale passes — will be verified by CI (not installed locally)
- [x] `CHANGELOG.md` updated
- [x] Auto-generated content left untouched
- [x] Tested manually — sidebar renders the new How-to Guides group in the local build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wTzuFzNofY8Z7m2LGivyT