### PR TITLE
Seven how-to guides: complete the sprint how-to backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the syllago documentation site.
 ## 2026-07-09
 
 ### Added
+- Seven new how-to guides completing the WTD Portland sprint backlog, all under `src/content/docs/using-syllago/how-to/`: `cursor-rules-to-claude-code.mdx` (#43), `windsurf-rules-to-cline.mdx` (#50), `keep-rules-in-sync.mdx` (#47), `preview-with-dry-run.mdx` (#48), `loadouts-work-vs-personal.mdx` (#49), `move-to-new-machine.mdx` (#44), and `install-from-github-registry.mdx` (#52, discovery-focused, cross-linking the community-skill guide rather than duplicating the install flow). All commands verified against the CLI reference — notably `loadout create` is interactive (no name argument) and `loadout apply` previews by default.
 - `src/content/docs/getting-started/why-syllago.mdx` — new "Is syllago right for you?" section with honest comparisons: syllago vs. maintaining files by hand, syllago vs. rulesync (including where rulesync wins — broader tool coverage, CI-friendly generator model), and an explicit "When not to use syllago" list (#37).
 - `src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx` — new task-based guide: import rules from Claude Code and install them into Cursor, with dry-run preview, verification steps, and an explanation of the Markdown→MDC conversion (#42).
 - `src/content/docs/using-syllago/how-to/install-community-skill.mdx` — new task-based guide: add a public registry, browse skills, and install one into Claude Code, including a MOAT trust-on-first-use note and verification steps (#46).
@@ -12,7 +13,7 @@ All notable changes to the syllago documentation site.
 
 ### Changed
 - `src/content/docs/getting-started/quick-start.mdx` — restructured from Write the Docs Portland stress-test feedback (#54, #55, #38): Installation prerequisite callout at the top; anchor links on the two paths; "follow the terminal prompts" cue with multi-select key hints and an explanation of the "no project markers found" warning; registry section now explains that registries are user-created git repos (with a pointer to `registry create`); the fake `team/ai-configs` example URL replaced with the official OpenScribbler meta-registry; install step moved ahead of `syllago list` so readers reach the payoff sooner.
-- `sidebar.ts` — new "How-to Guides" group under Using Syllago with the two new guides.
+- `sidebar.ts` — new "How-to Guides" group under Using Syllago with the two new guides; later expanded with the seven backlog guides (nine total).
 - `astro.config.mjs` — `starlight-llms-txt` now promotes the provider support matrix to the top of `llms-full.txt` so AI assistants can surface the provider list (#56).
 
 ### Fixed

--- a/sidebar.ts
+++ b/sidebar.ts
@@ -24,7 +24,14 @@ export const sidebar: SidebarItem[] = [
         collapsed: true,
         items: [
           { label: 'Claude Code rules into Cursor', slug: 'using-syllago/how-to/claude-code-rules-to-cursor' },
+          { label: 'Cursor rules into Claude Code', slug: 'using-syllago/how-to/cursor-rules-to-claude-code' },
+          { label: 'Windsurf rules into Cline', slug: 'using-syllago/how-to/windsurf-rules-to-cline' },
+          { label: 'Keep rules in sync', slug: 'using-syllago/how-to/keep-rules-in-sync' },
           { label: 'Install a community skill', slug: 'using-syllago/how-to/install-community-skill' },
+          { label: 'Install from a GitHub registry', slug: 'using-syllago/how-to/install-from-github-registry' },
+          { label: 'Preview with --dry-run', slug: 'using-syllago/how-to/preview-with-dry-run' },
+          { label: 'Loadouts: work vs. personal', slug: 'using-syllago/how-to/loadouts-work-vs-personal' },
+          { label: 'Move to a new machine', slug: 'using-syllago/how-to/move-to-new-machine' },
         ],
       },
       {

--- a/src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx
+++ b/src/content/docs/using-syllago/how-to/claude-code-rules-to-cursor.mdx
@@ -58,7 +58,7 @@ Open Cursor and the rule is active. You can also confirm syllago's view of the i
 
 ## What syllago converted for you
 
-Claude Code stores rules as plain Markdown; Cursor expects **MDC** format (`.mdc` files with metadata frontmatter like `description`, `alwaysApply`, and `globs`). syllago performs that conversion automatically during install — the copy in your library stays in canonical form, so the same rule can also be installed to any other provider. See [Format Conversion](/using-syllago/format-conversion/) for the details.
+Claude Code stores rules as plain Markdown; Cursor expects **Markdown Component (MDC)** format (`.mdc` files with metadata frontmatter like `description`, `alwaysApply`, and `globs`). syllago performs that conversion automatically during install — the copy in your library stays in canonical form, so the same rule can also be installed to any other provider. See [Format Conversion](/using-syllago/format-conversion/) for the details.
 
 ## Related
 

--- a/src/content/docs/using-syllago/how-to/cursor-rules-to-claude-code.mdx
+++ b/src/content/docs/using-syllago/how-to/cursor-rules-to-claude-code.mdx
@@ -58,7 +58,7 @@ Start a Claude Code session and the rule is part of its context.
 
 ## What syllago converted for you
 
-Cursor stores rules as **MDC** files (`.mdc` with `description`, `alwaysApply`, and `globs` frontmatter); Claude Code expects plain Markdown, with file-scoping expressed through a `paths` field. syllago maps the metadata and converts the format during install — your library copy stays canonical, so the same rule can go to any other provider too. See [Format Conversion](/using-syllago/format-conversion/) for the field-by-field details.
+Cursor stores rules as **Markdown Component (MDC)** files (`.mdc` with `description`, `alwaysApply`, and `globs` frontmatter); Claude Code expects plain Markdown, with file-scoping expressed through a `paths` field. syllago maps the metadata and converts the format during install — your library copy stays canonical, so the same rule can go to any other provider too. See [Format Conversion](/using-syllago/format-conversion/) for the field-by-field details.
 
 ## Related
 

--- a/src/content/docs/using-syllago/how-to/cursor-rules-to-claude-code.mdx
+++ b/src/content/docs/using-syllago/how-to/cursor-rules-to-claude-code.mdx
@@ -1,0 +1,67 @@
+---
+title: Get your Cursor rules into Claude Code
+description: Import rules from Cursor into your syllago library and install them into Claude Code, with format conversion handled automatically.
+---
+
+The reverse of [Claude Code rules into Cursor](/using-syllago/how-to/claude-code-rules-to-cursor/): you've built up rules in Cursor and want the same guidance in Claude Code.
+
+## What you need
+
+- syllago [installed](/getting-started/installation/) and initialized (`syllago init`)
+- Cursor with at least one rule configured (`.cursor/rules/` or `.cursorrules`)
+
+## 1. See what Cursor has
+
+```bash
+syllago add --from cursor
+```
+
+Discovery mode: this lists Cursor's available content without importing anything.
+
+## 2. Import the rules into your library
+
+```bash
+# Import all rules
+syllago add rules --from cursor
+
+# Or import one specific rule
+syllago add rules/typescript --from cursor
+```
+
+The rules land in your library (`~/.syllago/content/`) in syllago's canonical format. Run `syllago list` to confirm.
+
+## 3. Preview the install
+
+```bash
+syllago install typescript --to claude-code --dry-run
+```
+
+`--dry-run` shows exactly what would be written to Claude Code's directories without touching anything.
+
+## 4. Install to Claude Code
+
+```bash
+syllago install typescript --to claude-code
+```
+
+By default this is a **symlink**, so later edits to the rule in your library reach Claude Code immediately. Pass `--method copy` for a standalone file.
+
+## 5. Verify it worked
+
+Claude Code reads rules from `CLAUDE.md` and `.claude/rules/` in a project (and `~/.claude/rules/` globally). Check the install landed:
+
+```bash
+ls .claude/rules/
+```
+
+Start a Claude Code session and the rule is part of its context.
+
+## What syllago converted for you
+
+Cursor stores rules as **MDC** files (`.mdc` with `description`, `alwaysApply`, and `globs` frontmatter); Claude Code expects plain Markdown, with file-scoping expressed through a `paths` field. syllago maps the metadata and converts the format during install — your library copy stays canonical, so the same rule can go to any other provider too. See [Format Conversion](/using-syllago/format-conversion/) for the field-by-field details.
+
+## Related
+
+- [Claude Code provider reference](/using-syllago/providers/claude-code/rules/) — file locations and capability details
+- [`syllago add`](/using-syllago/cli-reference/add/) and [`syllago install`](/using-syllago/cli-reference/install/) — full flag reference
+- [Rules](/using-syllago/content-types/rules/) — how syllago models rules across providers

--- a/src/content/docs/using-syllago/how-to/install-from-github-registry.mdx
+++ b/src/content/docs/using-syllago/how-to/install-from-github-registry.mdx
@@ -1,0 +1,74 @@
+---
+title: Install content from a GitHub registry
+description: Find public syllago registries on GitHub, add one, and install what it offers.
+---
+
+GitHub-hosted registries are how most community syllago content gets shared: any public git repo with syllago's registry structure works, no publishing infrastructure required. This guide covers finding one and installing from it.
+
+## 1. Find a registry
+
+A few places to look:
+
+- **The official [syllago meta-registry](https://github.com/OpenScribbler/syllago-meta-registry)** — OpenScribbler's curated index; the best first stop.
+- **GitHub search** — search for `syllago registry`; a syllago registry is just a git repo following syllago's [content structure](/using-syllago/collections/registries/).
+- **Community links** — teams and authors typically share their registry URL directly in a README or docs page, like any other repo.
+
+Any public repo URL you can `git clone`, you can add.
+
+## 2. Add it
+
+```bash
+syllago registry add https://github.com/OpenScribbler/syllago-meta-registry.git
+```
+
+Two optional flags worth knowing:
+
+```bash
+# Give it a short alias for later commands
+syllago registry add https://github.com/OpenScribbler/syllago-meta-registry.git --name meta
+
+# Pin to a branch or tag instead of tracking the default branch
+syllago registry add https://github.com/OpenScribbler/syllago-meta-registry.git --ref v1.0
+```
+
+Pinning with `--ref` is the right call when you want updates on your schedule, not the maintainer's.
+
+## 3. Sync
+
+```bash
+syllago registry sync
+```
+
+This clones (or pulls) the registry locally. Syncing never touches your library or your providers — it only updates what's available to browse.
+
+## 4. Browse what's available
+
+```bash
+# Everything, across all your registries
+syllago registry items
+
+# Just one registry, just one content type
+syllago registry items meta --type rules
+```
+
+## 5. Install something
+
+```bash
+syllago install some-rule --to claude-code
+```
+
+syllago resolves the item from your registries, converts it for the target provider, and symlinks it into place — add `--dry-run` to preview first. For a worked end-to-end example of this step (including trust prompts and verification), see [Install a community skill into Claude Code](/using-syllago/how-to/install-community-skill/).
+
+## Keeping registry content up to date
+
+```bash
+syllago registry sync          # pull the latest registry content
+syllago refresh --all --dry-run  # see which installed items have updates
+syllago refresh --all          # apply them
+```
+
+## Related
+
+- [Registries](/using-syllago/collections/registries/) — how registries work and their structure
+- [MOAT trust tiers](/moat/trust-tiers/) — how syllago decides whether to trust a registry
+- [`syllago registry`](/using-syllago/cli-reference/registry/) — full command reference

--- a/src/content/docs/using-syllago/how-to/keep-rules-in-sync.mdx
+++ b/src/content/docs/using-syllago/how-to/keep-rules-in-sync.mdx
@@ -1,0 +1,72 @@
+---
+title: Keep rules in sync across multiple AI tools
+description: Edit a rule once and have the change reach every AI tool you use — and know what breaks that guarantee.
+---
+
+"Single source of truth" is syllago's core promise. This guide covers the ongoing workflow: where to make edits, how they propagate, and what silently breaks the sync if you're not careful.
+
+## How the sync model works
+
+When you run `syllago install`, the default method is a **symlink**: the file in the provider's directory points back at the canonical copy in your library (`~/.syllago/content/`). Edit the library copy and every symlinked install sees the change immediately — there is no regenerate or re-sync step.
+
+The exceptions: hooks and MCP configs are **merged into the provider's settings file** rather than linked, and anything installed with `--method copy` is a standalone snapshot. Those don't auto-propagate (see [What breaks sync](#what-breaks-sync) below).
+
+## Make edits in one place: the library
+
+The canonical copy of each item lives in your library. That's where edits go:
+
+```bash
+# Find the item
+syllago list --type rules
+
+# See where it lives and what's in it
+syllago inspect rules/typescript
+```
+
+Then edit the content file under `~/.syllago/content/rules/typescript/` with your editor of choice. Every provider with a symlinked install picks the change up instantly.
+
+Editing the file in a provider directory (say, `.cursor/rules/typescript.mdc`) is the wrong direction — see below.
+
+## Install to every tool you use
+
+Adding a new rule, or a new provider? Install from the library outward:
+
+```bash
+# One provider at a time
+syllago install typescript --to claude-code
+syllago install typescript --to cursor
+
+# Or every detected provider at once
+syllago install typescript --to-all
+
+# Or everything of one type, everywhere
+syllago install --type rules --to-all
+```
+
+Re-running `install` is safe: syllago tracks what's installed where and asks (or takes your `--on-clean` / `--on-modified` preference) when something already exists.
+
+## What breaks sync
+
+- **`--method copy`.** A copy is frozen at install time. Use it deliberately (e.g., a machine that can't resolve symlinks), and remember those installs need re-running after edits.
+- **Manual edits in provider directories.** Editing the provider-side file breaks the "library is canonical" assumption — with a symlink your edit actually lands in the library (fine, if surprising); with a copy it diverges silently. syllago detects stale install records and offers to reconcile (`--on-modified drop-record|append-fresh|keep`).
+- **Hooks and MCP configs.** These are merged into provider settings files, not symlinked. After editing one in your library, re-run `syllago install` for it.
+- **Registry items you don't refresh.** Content installed from a registry updates when *you* choose: `syllago registry sync` pulls the registry, then [`syllago refresh --all`](/using-syllago/cli-reference/refresh/) updates installed items that have newer versions (add `--dry-run` to preview).
+
+## Check what's installed where
+
+```bash
+# Everything syllago knows about, grouped by type
+syllago list
+
+# One item's full metadata, including install state
+syllago inspect rules/typescript
+
+# What would update from registries, without changing anything
+syllago refresh --all --dry-run
+```
+
+## Related
+
+- [Library](/using-syllago/collections/library/) — the canonical store and its layout
+- [`syllago install`](/using-syllago/cli-reference/install/) — install methods and reconciliation flags
+- [Format Conversion](/using-syllago/format-conversion/) — what happens to an item on its way into each provider

--- a/src/content/docs/using-syllago/how-to/loadouts-work-vs-personal.mdx
+++ b/src/content/docs/using-syllago/how-to/loadouts-work-vs-personal.mdx
@@ -1,0 +1,65 @@
+---
+title: Create loadouts for work vs. personal setups
+description: Use loadouts to switch your AI tools between a strict work configuration and a relaxed personal one.
+---
+
+Say your day job requires strict security rules — no external network calls in generated code, mandatory review comments, conservative dependency policies — but on personal projects you want a looser, experimental setup. A [loadout](/using-syllago/collections/loadouts/) is a named bundle of items you apply or revert as a unit, which makes "switch modes" a single command.
+
+## What you need
+
+- syllago [installed](/getting-started/installation/) and initialized (`syllago init`)
+- The rules for both setups already in your [library](/using-syllago/collections/library/) (import them with `syllago add` if they aren't)
+
+## 1. Create the work loadout
+
+```bash
+syllago loadout create
+```
+
+Loadout creation is interactive: it walks you through naming the loadout (call it `work`) and selecting which library items belong to it — your security rules, the compliance skill, the team MCP config.
+
+## 2. Create the personal loadout
+
+Run the same command again and build a `personal` loadout from your experimental rules and side-project skills:
+
+```bash
+syllago loadout create
+```
+
+## 3. Preview before switching
+
+`loadout apply` is **safe by default** — with no flags it only previews what would change:
+
+```bash
+syllago loadout apply work
+```
+
+Read the plan. Nothing has been modified yet.
+
+## 4. Switch between them
+
+Two ways to actually apply, depending on how committed you are:
+
+```bash
+# Temporary: reverts automatically when the session ends
+syllago loadout apply personal --try
+
+# Permanent: stays until you remove or replace it
+syllago loadout apply work --keep
+```
+
+`--try` is ideal for the "I'm doing an hour of side-project work" case; `--keep` for the Monday-morning switch back. Add `--to <provider>` to target a specific provider instead of the one the loadout declares.
+
+## 5. Check what's active
+
+```bash
+syllago loadout status
+```
+
+This tells you which loadout is currently applied — worth a glance before an AI session where the difference matters. `syllago loadout list` shows everything available, and `syllago loadout remove` undoes a `--keep`.
+
+## Related
+
+- [Loadouts](/using-syllago/collections/loadouts/) — the concept and how loadouts relate to your library
+- [`syllago loadout apply`](/using-syllago/cli-reference/loadout-apply/) — full flag reference
+- [Team Setup](/advanced/team-setup/) — loadouts as a team-onboarding tool

--- a/src/content/docs/using-syllago/how-to/move-to-new-machine.mdx
+++ b/src/content/docs/using-syllago/how-to/move-to-new-machine.mdx
@@ -1,0 +1,84 @@
+---
+title: Move your AI tool configs to a new machine
+description: Carry your whole syllago library — rules, skills, loadouts — to a new machine and reinstall everything in minutes.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+New laptop, fresh OS install, or a work/personal machine split: instead of recreating every AI tool's configuration by hand, move your syllago library once and reinstall from it.
+
+Your library is plain files under `~/.syllago/` — there's no database or hidden state — so migration is a copy plus a reinstall.
+
+## 1. On the old machine: copy your library
+
+Transfer the `~/.syllago/` directory however you move files between machines:
+
+```bash
+# Example: straight over SSH
+rsync -a ~/.syllago/ new-machine:~/.syllago/
+```
+
+That directory contains your content (`content/` — rules, skills, agents, hooks, commands, and loadouts) plus configuration. Registry clones don't need to travel — you'll re-add registries on the new machine and they'll re-clone.
+
+<Aside type="tip">
+If you expect to do this more than once, put your library in a personal git registry instead: scaffold one with [`syllago registry create --new`](/using-syllago/cli-reference/registry-create/), push it somewhere private, and a new machine becomes `registry add` + `sync` + `install` — no file copying at all. See [Team Setup](/advanced/team-setup/) for the same pattern at team scale.
+</Aside>
+
+## 2. On the new machine: install syllago
+
+Follow [Installation](/getting-started/installation/), then confirm:
+
+```bash
+syllago version
+```
+
+## 3. Verify the library arrived
+
+```bash
+syllago list
+```
+
+You should see your rules, skills, and other items grouped by type, exactly as on the old machine. If the list is empty, the `~/.syllago/` copy didn't land where syllago expects — check the path.
+
+## 4. Re-add your registries
+
+Registry clones are local caches, so add each registry again:
+
+```bash
+syllago registry add https://github.com/your-org/syllago-registry.git
+syllago registry sync
+```
+
+`syllago registry list` on the old machine tells you what you had.
+
+## 5. Reinstall content to your providers
+
+Initialize in your project (`syllago init` detects which AI tools are installed on the new machine), then push library content back out:
+
+```bash
+# Preview first
+syllago install --all --to claude-code --dry-run
+
+# Install everything to one provider
+syllago install --all --to claude-code
+
+# Or fan out to every detected provider
+syllago install --all --to-all
+```
+
+If you use [loadouts](/using-syllago/collections/loadouts/), they traveled with your library — `syllago loadout apply <name> --keep` recreates a whole configuration in one command.
+
+## 6. Verify
+
+```bash
+syllago list
+syllago loadout status
+```
+
+Then open one of your AI tools and confirm it sees its rules — for example, Claude Code should show your rules in context from `.claude/rules/` or `CLAUDE.md`.
+
+## Related
+
+- [Library](/using-syllago/collections/library/) — what lives in `~/.syllago/content/`
+- [`syllago install`](/using-syllago/cli-reference/install/) — bulk install flags
+- [Team Setup](/advanced/team-setup/) — the registry-based version of this workflow

--- a/src/content/docs/using-syllago/how-to/preview-with-dry-run.mdx
+++ b/src/content/docs/using-syllago/how-to/preview-with-dry-run.mdx
@@ -1,0 +1,43 @@
+---
+title: Preview changes with --dry-run
+description: See exactly what a syllago command would write, change, or delete — before it does.
+---
+
+Every syllago command that writes to disk supports `--dry-run`: run it and syllago prints what *would* happen, then exits without touching anything. It's the fastest way to build trust in a CLI that edits your AI tool configs.
+
+## Where it's supported
+
+| Command | What the dry run shows |
+|---------|------------------------|
+| [`syllago add`](/using-syllago/cli-reference/add/) | What would be imported into your library |
+| [`syllago install`](/using-syllago/cli-reference/install/) | Files/symlinks that would be created in the provider (also accepts `-n`) |
+| [`syllago refresh`](/using-syllago/cli-reference/refresh/) | Installed items that would be updated from registries |
+| [`syllago remove`](/using-syllago/cli-reference/remove/) | What would be deleted from your library |
+| [`syllago uninstall`](/using-syllago/cli-reference/uninstall/) | What would be removed from the provider's location |
+| [`syllago sync-install`](/using-syllago/cli-reference/sync-install/) | The combined registry-sync-then-install plan |
+
+[`syllago loadout apply`](/using-syllago/cli-reference/loadout-apply/) goes one step further: **preview is its default**. Running it with no flags never modifies anything; you opt into changes with `--try` or `--keep`.
+
+## Dry run vs. real run
+
+```bash
+# Preview: prints the plan, writes nothing
+syllago install typescript --to cursor --dry-run
+
+# Real: creates the symlink in Cursor's rules directory
+syllago install typescript --to cursor
+```
+
+The dry-run output lists the same target paths and conversions as the real run — the only difference is that nothing is written. If the plan looks wrong (wrong provider directory, unexpected format conversion, an item you didn't mean to touch), you've lost nothing.
+
+## When to use it
+
+- **Before your first use of any command** — cheap way to learn what it actually does
+- **Before anything destructive** — always before `remove` and `uninstall`
+- **Before bulk operations** — `--all`, `--to-all`, and `refresh --all` fan out; preview the fan-out first
+- **When a provider's directory layout matters** — confirm where files will land before writing there
+
+## Related
+
+- [Quick Start](/getting-started/quick-start/) — the flows these commands belong to
+- [Keep rules in sync](/using-syllago/how-to/keep-rules-in-sync/) — where dry runs fit the maintenance workflow

--- a/src/content/docs/using-syllago/how-to/windsurf-rules-to-cline.mdx
+++ b/src/content/docs/using-syllago/how-to/windsurf-rules-to-cline.mdx
@@ -1,0 +1,62 @@
+---
+title: Get your Windsurf rules into Cline
+description: Import rules from Windsurf into your syllago library and install them into Cline.
+---
+
+Moving rules between providers isn't limited to the big two. This guide takes rules from Windsurf into Cline — the same four-step flow works for any supported pair.
+
+## What you need
+
+- syllago [installed](/getting-started/installation/) and initialized (`syllago init`)
+- Windsurf with at least one rule configured (`.windsurf/rules/` or `.windsurfrules`)
+
+## 1. Import from Windsurf
+
+```bash
+# See what's available first
+syllago add --from windsurf
+
+# Import all rules
+syllago add rules --from windsurf
+```
+
+## 2. Review what was imported
+
+```bash
+syllago list --type rules
+```
+
+Each imported rule is now a canonical item in your library, independent of Windsurf.
+
+## 3. Preview the install
+
+```bash
+syllago install my-rule --to cline --dry-run
+```
+
+Nothing is written yet — the dry run shows the target paths and the converted content.
+
+## 4. Install to Cline
+
+```bash
+syllago install my-rule --to cline
+```
+
+Cline is a project-scoped provider: syllago writes into the current project's Cline config rather than a global directory, so run this from the project where you want the rule active.
+
+## 5. Verify it worked
+
+Cline reads rules from `.clinerules` in the project (and `~/Documents/Cline/Rules` globally):
+
+```bash
+ls .clinerules/
+```
+
+## Format differences to know about
+
+Both providers use Markdown rules, so the content itself carries over cleanly. The frontmatter differs: Windsurf supports `trigger`, `description`, and `globs`; Cline's rule format only expresses file scoping (its `paths` field, which syllago maps to and from `globs`). Windsurf-specific activation metadata like `trigger: manual` has no Cline equivalent — syllago warns when a field will degrade in translation, and you can check ahead of time with [`syllago compat`](/using-syllago/cli-reference/compat/).
+
+## Related
+
+- [Windsurf provider reference](/using-syllago/providers/windsurf/rules/) and [Cline provider reference](/using-syllago/providers/cline/rules/)
+- [Format Conversion](/using-syllago/format-conversion/) — how field mapping and degradation warnings work


### PR DESCRIPTION
## Summary

Completes the remaining how-to backlog from the WTD Portland sprint — seven new guides under `using-syllago/how-to/`, all wired into the sidebar:

- **Cursor rules into Claude Code** (#43) — mirror of the just-merged reverse guide, with MDC → Markdown conversion notes.
- **Windsurf rules into Cline** (#50) — includes honest degradation notes (Windsurf `trigger` has no Cline equivalent; `paths`/`globs` mapping) and Cline's project-scoped install behavior.
- **Keep rules in sync** (#47) — the symlink model, library-as-canonical-edit-point, and an explicit "what breaks sync" list (`--method copy`, provider-side edits, merged hooks/MCP, unrefreshed registry items).
- **Preview with --dry-run** (#48) — table of the six commands that support it, verified by grepping the CLI reference; notes that `loadout apply` previews *by default*.
- **Loadouts: work vs. personal** (#49) — corrected against the CLI reference: `loadout create` is interactive (the issue's `loadout create work` syntax doesn't exist) and `apply` needs `--try`/`--keep` to change anything.
- **Move to a new machine** (#44) — there's no export/import command, so the guide documents the honest path: copy `~/.syllago/` (plain files), re-add registries, bulk reinstall; with a tip recommending a personal git registry for repeat migrations.
- **Install from a GitHub registry** (#52) — discovery-focused; cross-links the community-skill guide for the shared install flow instead of duplicating it, per the consolidation concern flagged in triage.

Closes #43. Closes #44. Closes #47. Closes #48. Closes #49. Closes #50. Closes #52.

## Bead

N/A

## Checklist

- [x] `bun run build` (via `astro build` — 329 pages, all internal links valid)
- [x] `bun run lint:cli-refs` (clean, 240 files)
- [x] Vale passes — will be verified by CI (not installed locally)
- [x] `CHANGELOG.md` updated
- [x] Auto-generated content left untouched
- [x] Tested manually — sidebar renders all nine How-to entries in the local build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wTzuFzNofY8Z7m2LGivyT

---
_Generated by [Claude Code](https://claude.ai/code/session_016wTzuFzNofY8Z7m2LGivyT)_